### PR TITLE
Update Apache License header to reflect 2025 Bytedance-Seed copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
-
+   Copyright 2025 Bytedance-Seed
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
- Replaced placeholder copyright boilerplate in LICENSE appendix with “Copyright 2025 Bytedance-Seed”
- Ensured “Licensed under the Apache License, Version 2.0” notice is present and up-to-date